### PR TITLE
Add string, boolean and select custom knobs

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -45,6 +45,13 @@
   <section>
     <h2>&lt;api-viewer&gt; element</h2>
     <api-viewer src="./custom-elements.json">
+      <template data-element="expansion-panel" data-target="knob" data-attr="dir" data-type="select">
+        <select>
+          <option value=""></option>
+          <option value="ltr"></option>
+          <option value="rtl"></option>
+        </select>
+      </template>
       <template data-element="intl-currency" data-target="prefix">
         <em>
           Shipping:

--- a/src/api-viewer-demo-layout.ts
+++ b/src/api-viewer-demo-layout.ts
@@ -243,22 +243,32 @@ export class ApiViewerDemoLayout extends LitElement {
       .map(template => {
         const { attr, type } = template.dataset;
         let result = null;
-        if (attr && type === 'select') {
-          const node = getTemplateNode(template);
-          const options = node
-            ? Array.from(node.children)
-                .filter(
-                  (c): c is HTMLOptionElement => c instanceof HTMLOptionElement
-                )
-                .map(option => option.value)
-            : [];
-          if (node instanceof HTMLSelectElement && options.length > 1) {
+        if (attr) {
+          if (type === 'select') {
+            const node = getTemplateNode(template);
+            const options = node
+              ? Array.from(node.children)
+                  .filter(
+                    (c): c is HTMLOptionElement =>
+                      c instanceof HTMLOptionElement
+                  )
+                  .map(option => option.value)
+              : [];
+            if (node instanceof HTMLSelectElement && options.length > 1) {
+              result = {
+                name: attr,
+                attribute: attr,
+                type,
+                options
+              };
+            }
+          }
+          if (type === 'string' || type === 'boolean') {
             result = {
               name: attr,
               attribute: attr,
-              type,
-              options
-            } as PropertyInfo;
+              type
+            };
           }
         }
         return result;

--- a/src/api-viewer-demo-layout.ts
+++ b/src/api-viewer-demo-layout.ts
@@ -26,6 +26,7 @@ import {
   getTemplates,
   hasTemplate,
   isEmptyArray,
+  isPropMatch,
   normalizeType,
   TemplateTypes,
   unquote,
@@ -298,19 +299,14 @@ export class ApiViewerDemoLayout extends LitElement {
   }
 
   private _getProp(name: string): { prop?: PropertyInfo; custom?: boolean } {
-    const isMatch = (p: PropertyInfo) =>
-      p.attribute === name || p.name === name;
+    const isMatch = isPropMatch(name);
     const prop = this.props.find(isMatch);
-    let result = {};
-    if (prop) {
-      result = { prop };
-    } else {
-      result = {
-        prop: this.customKnobs.find(isMatch),
-        custom: true
-      };
-    }
-    return result;
+    return prop
+      ? { prop }
+      : {
+          prop: this.customKnobs.find(isMatch),
+          custom: true
+        };
   }
 
   private _onLogClear() {

--- a/src/api-viewer-docs.ts
+++ b/src/api-viewer-docs.ts
@@ -14,7 +14,7 @@ import {
   CSSPartInfo,
   CSSPropertyInfo
 } from './lib/types.js';
-import { isEmptyArray, unquote } from './lib/utils.js';
+import { isEmptyArray, isPropMatch, unquote } from './lib/utils.js';
 import { parse } from './lib/markdown.js';
 
 import './api-viewer-panel.js';
@@ -24,16 +24,6 @@ import './api-viewer-tab.js';
 import './api-viewer-tabs.js';
 import { ApiViewerTabs } from './api-viewer-tabs.js';
 /* eslint-enable import/no-duplicates */
-
-const processAttrs = (
-  attrs: AttributeInfo[],
-  props: PropertyInfo[]
-): AttributeInfo[] => {
-  return attrs.filter(
-    ({ name }) =>
-      !props.some(prop => prop.attribute === name || prop.name === name)
-  );
-};
 
 const renderItem = (
   prefix: string,
@@ -132,7 +122,9 @@ export class ApiViewerDocs extends LitElement {
     const { slots, props, attrs, events, cssParts, cssProps } = this;
 
     const properties = props || [];
-    const attributes = processAttrs(attrs || [], properties);
+    const attributes = (attrs || []).filter(
+      ({ name }) => !properties.some(isPropMatch(name))
+    );
 
     const emptyDocs = [
       properties,

--- a/src/api-viewer-styles.ts
+++ b/src/api-viewer-styles.ts
@@ -199,7 +199,7 @@ export default css`
 
   [part='knobs'] {
     display: flex;
-    padding: 1rem;
+    padding: 0 1rem 1rem;
   }
 
   [part='knobs-column'] {
@@ -209,7 +209,7 @@ export default css`
   [part='knobs-header'] {
     font-size: 1rem;
     font-weight: bold;
-    margin: 0 0 0.25rem;
+    margin: 1rem 0 0.25rem;
   }
 
   td {

--- a/src/fixtures/expansion-panel.ts
+++ b/src/fixtures/expansion-panel.ts
@@ -165,6 +165,11 @@ export class ExpansionPanel extends LitElement {
       :host([opened]) [part='toggle'] {
         transform: rotate(225deg);
       }
+
+      :host([dir='rtl']) [part='toggle'] {
+        left: 8px;
+        right: auto;
+      }
     `;
   }
 

--- a/src/lib/knobs.ts
+++ b/src/lib/knobs.ts
@@ -32,10 +32,25 @@ export const cssPropRenderer: InputRenderer = (knob: Knob, id: string) => {
 };
 
 export const propRenderer: InputRenderer = (knob: Knob, id: string) => {
-  const { name, type, value } = knob as PropertyInfo;
+  const { name, type, value, options } = knob as PropertyInfo;
   const inputType = getInputType(type);
   let input;
-  if (value === undefined) {
+  if (type === 'select' && Array.isArray(options)) {
+    input = html`
+      <select
+        id="${id}"
+        type="${inputType}"
+        data-name="${name}"
+        data-type="${type}"
+        part="select"
+        >${options.map(
+          option => html`
+            <option value="${option}">${option}</option>
+          `
+        )}
+      </select>
+    `;
+  } else if (value === undefined) {
     input = html`
       <input
         id="${id}"

--- a/src/lib/renderer.ts
+++ b/src/lib/renderer.ts
@@ -21,8 +21,13 @@ const caches = new WeakMap();
 const applyKnobs = (component: Element, knobs: KnobValues) => {
   Object.keys(knobs).forEach((key: string) => {
     const { type, attribute, value } = knobs[key];
-
-    if (normalizeType(type) === 'boolean') {
+    if (type === 'select' && attribute) {
+      if (typeof value === 'string' && value) {
+        component.setAttribute(attribute, value);
+      } else {
+        component.removeAttribute(attribute);
+      }
+    } else if (normalizeType(type) === 'boolean') {
       component.toggleAttribute(attribute || key, Boolean(value));
     } else {
       ((component as unknown) as ComponentWithProps)[key] = value;

--- a/src/lib/renderer.ts
+++ b/src/lib/renderer.ts
@@ -20,8 +20,8 @@ const caches = new WeakMap();
 
 const applyKnobs = (component: Element, knobs: KnobValues) => {
   Object.keys(knobs).forEach((key: string) => {
-    const { type, attribute, value } = knobs[key];
-    if (type === 'select' && attribute) {
+    const { type, attribute, value, custom } = knobs[key];
+    if (custom && attribute) {
       if (typeof value === 'string' && value) {
         component.setAttribute(attribute, value);
       } else {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -32,6 +32,7 @@ export interface KnobValue {
   type: string;
   attribute: string | undefined;
   value: string | number | boolean | null;
+  custom?: boolean;
 }
 
 export type KnobValues = { [name: string]: KnobValue };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -25,6 +25,7 @@ export interface PropertyInfo extends Info {
   attribute: string | undefined;
   value: string | number | boolean | null | undefined;
   default: string | number | boolean | null | undefined;
+  options?: string[];
 }
 
 export interface KnobValue {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -10,6 +10,7 @@ export const setTemplates = (id: number, tpl: HTMLTemplateElement[]) => {
 
 export const TemplateTypes = Object.freeze({
   HOST: 'host',
+  KNOB: 'knob',
   SLOT: 'slot',
   PREFIX: 'prefix',
   SUFFIX: 'suffix',
@@ -31,6 +32,9 @@ export const getTemplateNode = (node: unknown) =>
 
 export const getTemplate = (id: number, name: string, type: string) =>
   templates[id].find(matchTemplate(name, type));
+
+export const getTemplates = (id: number, name: string, type: string) =>
+  templates[id].filter(matchTemplate(name, type));
 
 export const hasTemplate = (id: number, name: string, type: string) =>
   templates[id].some(matchTemplate(name, type));

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,3 +1,5 @@
+import { PropertyInfo } from './types';
+
 export const getSlotTitle = (name: string) => {
   return name === '' ? 'Default' : name[0].toUpperCase() + name.slice(1);
 };
@@ -40,6 +42,9 @@ export const hasTemplate = (id: number, name: string, type: string) =>
   templates[id].some(matchTemplate(name, type));
 
 export const isEmptyArray = (array: unknown[]) => array.length === 0;
+
+export const isPropMatch = (name: string) => (prop: PropertyInfo) =>
+  prop.attribute === name || prop.name === name;
 
 export const normalizeType = (type: string | undefined = '') =>
   type.replace(' | undefined', '').replace(' | null', '');


### PR DESCRIPTION
Fixes #17 

Decided to exclude multi-select knob (checkbox group) for now due to complexity it brings.

Using `string` knob should be enough to make it possible to set `theme` attribute value.
Will reconsider an option to add multi-select knob support in future.
