### PR TITLE
Add separate docs and demo components

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -5,12 +5,11 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
   <title>API viewer demo</title>
-  <!-- Uncomment to run demo in Edge
-  <script src="../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
-  -->
   <style>
     body {
       margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+        'Oxygen-Sans', Ubuntu, Cantarell, sans-serif;
     }
 
     section {
@@ -20,29 +19,49 @@
 
     h2 {
       margin: 0 0 0.5rem;
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
-        'Oxygen-Sans', Ubuntu, Cantarell, sans-serif;
       text-align: center;
     }
 
-    .parts h2 {
-      animation: fadein 3s;
+    nav {
+      display: flex;
+      justify-content: space-between;
+      max-width: 480px;
+      margin: 0 auto;
     }
 
-    @keyframes fadein {
-      from {
-        opacity: 0;
-      }
+    a {
+      display: block;
+      padding: 8px;
+      color: #01579b;
+    }
 
-      to {
-        opacity: 1;
-      }
+    a:hover {
+      color: red;
+    }
+
+    #bonus {
+      display: none;
+    }
+
+    section:not(:target) {
+      display: none;
+    }
+
+    section:target {
+      display: block;
     }
   </style>
   <link rel="stylesheet" href="./styles.css">
 </head>
 <body>
-  <section>
+  <nav>
+    <a href="#api-viewer">&lt;api-viewer&gt;</a>
+    <a href="#api-docs">&lt;api-docs&gt;</a>
+    <a href="#api-demo">&lt;api-demo&gt;</a>
+    <a href="#shadow-parts" id="bonus">Shadow Parts</a>
+  </nav>
+
+  <section id="api-viewer" class="initial">
     <h2>&lt;api-viewer&gt; element</h2>
     <api-viewer src="./custom-elements.json">
       <template data-element="expansion-panel" data-target="knob" data-attr="dir" data-type="select">
@@ -51,17 +70,6 @@
           <option value="ltr"></option>
           <option value="rtl"></option>
         </select>
-      </template>
-      <template data-element="intl-currency" data-target="prefix">
-        <em>
-          Shipping:
-        </em>
-      </template>
-      <template data-element="intl-currency" data-target="suffix">
-        <strong style="text-transform: uppercase">free!</strong>
-      </template>
-      <template data-element="intl-currency" data-target="wrapper">
-        <s></s>
       </template>
       <template data-element="fancy-accordion" data-target="slot">
         <expansion-panel>
@@ -77,16 +85,80 @@
           <div>Content 3</div>
         </expansion-panel>
       </template>
+      <template data-element="intl-currency" data-target="prefix">
+        <em>
+          Shipping:
+        </em>
+      </template>
+      <template data-element="intl-currency" data-target="suffix">
+        <strong style="text-transform: uppercase">free!</strong>
+      </template>
+      <template data-element="intl-currency" data-target="wrapper">
+        <s></s>
+      </template>
       <template data-element="progress-bar" data-target="host">
         <progress-bar max="100" min="1" value="50"></progress-bar>
       </template>
     </api-viewer>
   </section>
 
+  <section id="api-docs">
+    <h2>&lt;api-docs&gt; element</h2>
+    <api-docs src="./custom-elements.json"></api-docs>
+  </section>
+
+  <section id="api-demo">
+    <h2>&lt;api-demo&gt; element</h2>
+    <api-demo src="./custom-elements.json">
+      <template data-element="expansion-panel" data-target="knob" data-attr="dir" data-type="select">
+        <select>
+          <option value=""></option>
+          <option value="ltr"></option>
+          <option value="rtl"></option>
+        </select>
+      </template>
+      <template data-element="fancy-accordion" data-target="slot">
+        <expansion-panel>
+          <div slot="header">Panel 1</div>
+          <div>Content 1</div>
+        </expansion-panel>
+        <expansion-panel disabled>
+          <div slot="header">Panel 2</div>
+          <div>Content 2</div>
+        </expansion-panel>
+        <expansion-panel>
+          <div slot="header">Panel 3</div>
+          <div>Content 3</div>
+        </expansion-panel>
+      </template>
+      <template data-element="intl-currency" data-target="prefix">
+        <em>
+          Shipping:
+        </em>
+      </template>
+      <template data-element="intl-currency" data-target="suffix">
+        <strong style="text-transform: uppercase">free!</strong>
+      </template>
+      <template data-element="intl-currency" data-target="wrapper">
+        <s></s>
+      </template>
+      <template data-element="progress-bar" data-target="host">
+        <progress-bar max="100" min="1" value="50"></progress-bar>
+      </template>
+    </api-demo>
+  </section>
+
   <template id="parts">
-    <section class="parts">
-      <h2>Bonus: CSS shadow parts</h2>
+    <section id="shadow-parts" class="parts">
+      <h2>CSS shadow parts</h2>
       <api-viewer src="./custom-elements.json" class="custom">
+        <template data-element="expansion-panel" data-target="knob" data-attr="dir" data-type="select">
+          <select>
+            <option value=""></option>
+            <option value="ltr"></option>
+            <option value="rtl"></option>
+          </select>
+        </template>
         <template data-element="fancy-accordion" data-target="slot">
           <expansion-panel>
             <div slot="header">Panel 1</div>
@@ -101,6 +173,17 @@
             <div>Content 3</div>
           </expansion-panel>
         </template>
+        <template data-element="intl-currency" data-target="prefix">
+          <em>
+            Shipping:
+          </em>
+        </template>
+        <template data-element="intl-currency" data-target="suffix">
+          <strong style="text-transform: uppercase">free!</strong>
+        </template>
+        <template data-element="intl-currency" data-target="wrapper">
+          <s></s>
+        </template>
         <template data-element="progress-bar" data-target="host">
           <progress-bar max="100" min="1" value="50"></progress-bar>
         </template>
@@ -113,12 +196,29 @@
   <script type="module" src="../lib/fixtures/intl-currency.js"></script>
   <script type="module" src="../lib/fixtures/progress-bar.js"></script>
   <script type="module" src="../lib/api-viewer.js"></script>
+  <script type="module" src="../lib/api-docs.js"></script>
+  <script type="module" src="../lib/api-demo.js"></script>
 
   <script>
+    if (window.location.hash === '') {
+      history.pushState({}, '', '#api-viewer');
+    }
+
+    Array.from(document.querySelectorAll('a[href^="#"]')).forEach(link => {
+      link.addEventListener('click', event => {
+        event.preventDefault();
+        history.pushState({}, '', link.href);
+        history.pushState({}, '', link.href);
+        history.back();
+      });
+    });
+
     if ('part' in HTMLElement.prototype) {
       window.requestAnimationFrame(() => {
         const tpl = document.getElementById('parts');
         document.body.insertBefore(tpl.content.cloneNode(true), tpl);
+
+        document.getElementById('bonus').style.display = 'block';
       });
     }
   </script>

--- a/src/api-demo-base.ts
+++ b/src/api-demo-base.ts
@@ -1,0 +1,61 @@
+import { LitElement, html, property, TemplateResult } from 'lit-element';
+import { until } from 'lit-html/directives/until.js';
+import { ElementPromise } from './lib/types.js';
+import { setTemplates } from './lib/utils.js';
+import { ApiViewerMixin, emptyDataWarning } from './api-viewer-mixin.js';
+import './api-demo-content.js';
+
+async function renderDemo(
+  jsonFetched: ElementPromise,
+  selected?: string,
+  id?: number,
+  exclude = ''
+): Promise<TemplateResult> {
+  const elements = await jsonFetched;
+
+  const index = elements.findIndex(el => el.name === selected);
+
+  return elements.length
+    ? html`
+        <api-demo-content
+          .elements="${elements}"
+          .selected="${index >= 0 ? index : 0}"
+          .exclude="${exclude}"
+          .vid="${id}"
+        ></api-demo-content>
+      `
+    : emptyDataWarning;
+}
+
+let id = 0;
+
+export class ApiDemoBase extends ApiViewerMixin(LitElement) {
+  @property({ type: String, attribute: 'exclude-knobs' }) excludeKnobs?: string;
+
+  protected _id?: number;
+
+  constructor() {
+    super();
+
+    this._id = id++;
+  }
+
+  protected render() {
+    return html`
+      ${until(
+        renderDemo(this.jsonFetched, this.selected, this._id, this.excludeKnobs)
+      )}
+    `;
+  }
+
+  protected firstUpdated() {
+    this.setTemplates();
+  }
+
+  protected setTemplates() {
+    setTemplates(
+      this._id as number,
+      Array.from(this.querySelectorAll('template'))
+    );
+  }
+}

--- a/src/api-demo-content.ts
+++ b/src/api-demo-content.ts
@@ -1,0 +1,74 @@
+import { LitElement, html, customElement, property } from 'lit-element';
+import { ElementInfo } from './lib/types.js';
+import { EMPTY_ELEMENT } from './lib/constants.js';
+import './api-viewer-demo.js';
+
+@customElement('api-demo-content')
+export class ApiDemoContent extends LitElement {
+  @property({ attribute: false }) elements: ElementInfo[] = [];
+
+  @property({ type: Number }) selected = 0;
+
+  @property({ type: String }) exclude = '';
+
+  @property({ type: Number }) vid?: number;
+
+  protected createRenderRoot() {
+    return this;
+  }
+
+  protected render() {
+    const { elements, selected, exclude, vid } = this;
+
+    const { name, properties, slots, events, cssProperties } = {
+      ...EMPTY_ELEMENT,
+      ...(elements[selected] || {})
+    };
+
+    // TODO: analyzer should sort CSS custom properties
+    const cssProps = (cssProperties || []).sort((a, b) =>
+      a.name > b.name ? 1 : -1
+    );
+
+    return html`
+      <header part="header">
+        <div part="header-title">&lt;${name}&gt;</div>
+        <nav>
+          <label part="select-label">
+            <select
+              @change="${this._onSelect}"
+              .value="${String(selected)}"
+              ?hidden="${elements.length === 1}"
+              part="select"
+            >
+              ${elements.map((tag, idx) => {
+                return html`
+                  <option value="${idx}">${tag.name}</option>
+                `;
+              })}
+            </select>
+          </label>
+        </nav>
+      </header>
+      <api-viewer-demo
+        .name="${name}"
+        .props="${properties}"
+        .slots="${slots}"
+        .events="${events}"
+        .cssProps="${cssProps}"
+        .exclude="${exclude}"
+        .vid="${vid}"
+      ></api-viewer-demo>
+    `;
+  }
+
+  private _onSelect(e: CustomEvent) {
+    this.selected = Number((e.target as HTMLSelectElement).value);
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'api-demo-content': ApiDemoContent;
+  }
+}

--- a/src/api-demo-styles.ts
+++ b/src/api-demo-styles.ts
@@ -1,0 +1,104 @@
+import { css } from 'lit-element';
+
+export default css`
+  pre {
+    white-space: pre-wrap;
+  }
+
+  button {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    text-transform: uppercase;
+    border: none;
+    border-radius: 0.25em;
+    cursor: pointer;
+    background: var(--ave-button-background, rgba(0, 0, 0, 0.3));
+    color: var(--ave-button-color, #fff);
+  }
+
+  button:focus,
+  button:hover {
+    background: var(--ave-button-active-background, rgba(0, 0, 0, 0.6));
+  }
+
+  api-viewer-demo,
+  api-viewer-demo-layout {
+    display: block;
+  }
+
+  [part='demo-tabs'],
+  [part='demo-output'] {
+    border-top: solid 1px var(--ave-border-color);
+  }
+
+  [part='demo-tabs'] [part='tab-panel'] {
+    box-sizing: border-box;
+    position: relative;
+    background: #fafafa;
+  }
+
+  [part='demo-output'] {
+    padding: 1.5rem;
+    text-align: initial;
+    transform: translateZ(0);
+    overflow: hidden;
+  }
+
+  .source {
+    position: relative;
+  }
+
+  [part='knobs'] {
+    display: flex;
+    padding: 0 1rem 1rem;
+  }
+
+  [part='knobs-column'] {
+    width: 50%;
+  }
+
+  [part='knobs-header'] {
+    font-size: 1rem;
+    font-weight: bold;
+    margin: 1rem 0 0.25rem;
+  }
+
+  td {
+    padding: 0.25rem 0.25rem 0.25rem 0;
+    font-size: 0.9375rem;
+    white-space: nowrap;
+  }
+
+  [part='event-log'] {
+    display: block;
+    padding: 0 1rem;
+    min-height: 50px;
+    max-height: 200px;
+    overflow: auto;
+  }
+
+  [part='event-record'] {
+    margin: 0 0 0.25rem;
+    font-family: var(--ave-monospace-font);
+    font-size: 0.875rem;
+  }
+
+  [part='event-record']:first-of-type {
+    margin-top: 1rem;
+  }
+
+  [part='event-record']:last-of-type {
+    margin-bottom: 1rem;
+  }
+
+  @media (max-width: 480px) {
+    [part='knobs'] {
+      flex-direction: column;
+    }
+
+    [part='knobs-column']:not(:last-child) {
+      margin-bottom: 1rem;
+    }
+  }
+`;

--- a/src/api-demo.ts
+++ b/src/api-demo.ts
@@ -1,0 +1,25 @@
+import { customElement, css } from 'lit-element';
+import { ApiDemoBase } from './api-demo-base.js';
+import demoStyles from './api-demo-styles.js';
+import sharedStyles from './shared-styles.js';
+
+@customElement('api-demo')
+export class ApiDemo extends ApiDemoBase {
+  static get styles() {
+    return [
+      sharedStyles,
+      demoStyles,
+      css`
+        api-demo-content {
+          display: block;
+        }
+      `
+    ];
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'api-demo': ApiDemo;
+  }
+}

--- a/src/api-docs-base.ts
+++ b/src/api-docs-base.ts
@@ -1,7 +1,7 @@
 import { LitElement, html, TemplateResult } from 'lit-element';
 import { until } from 'lit-html/directives/until.js';
 import { ElementPromise } from './lib/types.js';
-import { ApiViewerMixin } from './api-viewer-mixin.js';
+import { ApiViewerMixin, emptyDataWarning } from './api-viewer-mixin.js';
 import './api-docs-content.js';
 
 async function renderDocs(
@@ -19,11 +19,7 @@ async function renderDocs(
           .selected="${index >= 0 ? index : 0}"
         ></api-docs-content>
       `
-    : html`
-        <div part="warning">
-          No custom elements found in the JSON file.
-        </div>
-      `;
+    : emptyDataWarning;
 }
 
 export class ApiDocsBase extends ApiViewerMixin(LitElement) {

--- a/src/api-docs-base.ts
+++ b/src/api-docs-base.ts
@@ -1,0 +1,35 @@
+import { LitElement, html, TemplateResult } from 'lit-element';
+import { until } from 'lit-html/directives/until.js';
+import { ElementPromise } from './lib/types.js';
+import { ApiViewerMixin } from './api-viewer-mixin.js';
+import './api-docs-content.js';
+
+async function renderDocs(
+  jsonFetched: ElementPromise,
+  selected?: string
+): Promise<TemplateResult> {
+  const elements = await jsonFetched;
+
+  const index = elements.findIndex(el => el.name === selected);
+
+  return elements.length
+    ? html`
+        <api-docs-content
+          .elements="${elements}"
+          .selected="${index >= 0 ? index : 0}"
+        ></api-docs-content>
+      `
+    : html`
+        <div part="warning">
+          No custom elements found in the JSON file.
+        </div>
+      `;
+}
+
+export class ApiDocsBase extends ApiViewerMixin(LitElement) {
+  protected render() {
+    return html`
+      ${until(renderDocs(this.jsonFetched, this.selected))}
+    `;
+  }
+}

--- a/src/api-docs-content.ts
+++ b/src/api-docs-content.ts
@@ -1,0 +1,80 @@
+import { LitElement, html, customElement, property } from 'lit-element';
+import { ElementInfo } from './lib/types.js';
+import { EMPTY_ELEMENT } from './lib/constants.js';
+import { parse } from './lib/markdown.js';
+import './api-viewer-docs.js';
+
+@customElement('api-docs-content')
+export class ApiDocsContent extends LitElement {
+  @property({ attribute: false }) elements: ElementInfo[] = [];
+
+  @property({ type: Number }) selected = 0;
+
+  protected createRenderRoot() {
+    return this;
+  }
+
+  protected render() {
+    const { elements, selected } = this;
+
+    const {
+      name,
+      description,
+      properties,
+      attributes,
+      slots,
+      events,
+      cssParts,
+      cssProperties
+    } = { ...EMPTY_ELEMENT, ...(elements[selected] || {}) };
+
+    // TODO: analyzer should sort CSS custom properties
+    const cssProps = (cssProperties || []).sort((a, b) =>
+      a.name > b.name ? 1 : -1
+    );
+
+    return html`
+      <header part="header">
+        <div part="header-title">&lt;${name}&gt;</div>
+        <nav>
+          <label part="select-label">
+            <select
+              @change="${this._onSelect}"
+              .value="${String(selected)}"
+              ?hidden="${elements.length === 1}"
+              part="select"
+            >
+              ${elements.map((tag, idx) => {
+                return html`
+                  <option value="${idx}">${tag.name}</option>
+                `;
+              })}
+            </select>
+          </label>
+        </nav>
+      </header>
+      <div ?hidden="${description === ''}" part="docs-description">
+        ${parse(description)}
+      </div>
+      <api-viewer-docs
+        .name="${name}"
+        .props="${properties}"
+        .attrs="${attributes}"
+        .events="${events}"
+        .slots="${slots}"
+        .cssParts="${cssParts}"
+        .cssProps="${cssProps}"
+      ></api-viewer-docs>
+    `;
+  }
+
+  private _onSelect(e: CustomEvent) {
+    this.selected = Number((e.target as HTMLSelectElement).value);
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'api-docs-content': ApiDocsContent;
+  }
+}

--- a/src/api-docs-styles.ts
+++ b/src/api-docs-styles.ts
@@ -1,0 +1,94 @@
+import { css } from 'lit-element';
+
+export default css`
+  p,
+  ul,
+  ol {
+    margin: 1rem 0;
+    font-size: 0.9375rem;
+    line-height: 1.5;
+  }
+
+  a {
+    color: var(--ave-link-color);
+  }
+
+  a:hover {
+    color: var(--ave-link-hover-color);
+  }
+
+  api-viewer-docs {
+    display: block;
+  }
+
+  [part='tab'][heading^='CSS'] {
+    font-size: 0.8125rem;
+  }
+
+  [part='docs-item'] {
+    display: block;
+    padding: 0.5rem;
+    color: var(--ave-item-color);
+  }
+
+  [part='docs-item']:not(:first-of-type) {
+    border-top: solid 1px var(--ave-border-color);
+  }
+
+  [part='docs-description'] {
+    display: block;
+    padding: 0 1rem;
+    border-bottom: solid 1px var(--ave-border-color);
+  }
+
+  [part='docs-row'] {
+    display: flex;
+    flex-wrap: wrap;
+    margin-bottom: 1rem;
+  }
+
+  [part='docs-column'] {
+    box-sizing: border-box;
+    flex-basis: 25%;
+    padding-right: 0.5rem;
+  }
+
+  [part='docs-column']:only-child {
+    flex-basis: 100%;
+  }
+
+  .column-name-css,
+  .column-type {
+    flex-basis: 50%;
+  }
+
+  [part='docs-label'] {
+    color: var(--ave-label-color);
+    font-size: 0.75rem;
+    line-height: 1rem;
+    letter-spacing: 0.1rem;
+  }
+
+  [part='docs-value'] {
+    font-family: var(--ave-monospace-font);
+    font-size: 0.875rem;
+    line-height: 1.5rem;
+  }
+
+  [part='docs-markdown'] p,
+  [part='docs-markdown'] ul,
+  [part='docs-markdown'] ol {
+    margin: 0.5rem 0;
+  }
+
+  .accent {
+    color: var(--ave-accent-color);
+  }
+
+  @media (max-width: 480px) {
+    .column-type {
+      flex-basis: 100%;
+      margin-top: 1rem;
+    }
+  }
+`;

--- a/src/api-docs.ts
+++ b/src/api-docs.ts
@@ -1,0 +1,25 @@
+import { customElement, css } from 'lit-element';
+import { ApiDocsBase } from './api-docs-base.js';
+import docsStyles from './api-docs-styles.js';
+import sharedStyles from './shared-styles.js';
+
+@customElement('api-docs')
+export class ApiDocs extends ApiDocsBase {
+  static get styles() {
+    return [
+      sharedStyles,
+      docsStyles,
+      css`
+        api-docs-content {
+          display: block;
+        }
+      `
+    ];
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'api-docs': ApiDocs;
+  }
+}

--- a/src/api-viewer-base.ts
+++ b/src/api-viewer-base.ts
@@ -2,7 +2,7 @@ import { LitElement, html, property, TemplateResult } from 'lit-element';
 import { until } from 'lit-html/directives/until.js';
 import { ElementPromise } from './lib/types.js';
 import { setTemplates } from './lib/utils.js';
-import { ApiViewerMixin } from './api-viewer-mixin.js';
+import { ApiViewerMixin, emptyDataWarning } from './api-viewer-mixin.js';
 import './api-viewer-content.js';
 
 async function renderDocs(
@@ -26,11 +26,7 @@ async function renderDocs(
           .vid="${id}"
         ></api-viewer-content>
       `
-    : html`
-        <div part="warning">
-          No custom elements found in the JSON file.
-        </div>
-      `;
+    : emptyDataWarning;
 }
 
 let id = 0;

--- a/src/api-viewer-content.ts
+++ b/src/api-viewer-content.ts
@@ -43,7 +43,7 @@ export class ApiViewerContent extends LitElement {
 
     return html`
       <header part="header">
-        <div class="tag-name">&lt;${name}&gt;</div>
+        <div part="header-title">&lt;${name}&gt;</div>
         <nav>
           <input
             id="docs"

--- a/src/api-viewer-mixin.ts
+++ b/src/api-viewer-mixin.ts
@@ -1,4 +1,4 @@
-import { LitElement, property, PropertyValues } from 'lit-element';
+import { LitElement, html, property, PropertyValues } from 'lit-element';
 import { ElementInfo, ElementPromise, ElementSetInfo } from './lib/types.js';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -29,6 +29,12 @@ export async function fetchJson(src: string): ElementPromise {
   }
   return result;
 }
+
+export const emptyDataWarning = html`
+  <div part="warning">
+    No custom elements found in the JSON file.
+  </div>
+`;
 
 export const ApiViewerMixin = <T extends Constructor<LitElement>>(
   base: T

--- a/src/api-viewer-styles.ts
+++ b/src/api-viewer-styles.ts
@@ -1,55 +1,13 @@
 import { css } from 'lit-element';
+import sharedStyles from './shared-styles.js';
+import docsStyles from './api-docs-styles.js';
 
 export default css`
-  :host {
-    display: block;
-    text-align: left;
-    box-sizing: border-box;
-    max-width: 800px;
-    min-width: 360px;
-    font-size: 1rem;
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
-      'Oxygen-Sans', Ubuntu, Cantarell, sans-serif;
-    border: 1px solid var(--ave-border-color);
-    border-radius: var(--ave-border-radius);
-
-    --ave-primary-color: #01579b;
-    --ave-accent-color: #d63200;
-    --ave-border-color: rgba(0, 0, 0, 0.12);
-    --ave-border-radius: 4px;
-    --ave-header-color: #fff;
-    --ave-item-color: rgba(0, 0, 0, 0.87);
-    --ave-label-color: #424242;
-    --ave-link-color: #01579b;
-    --ave-link-hover-color: #d63200;
-    --ave-tab-indicator-size: 2px;
-    --ave-tab-color: rgba(0, 0, 0, 0.54);
-    --ave-monospace-font: Menlo, 'DejaVu Sans Mono', 'Liberation Mono', Consolas,
-      'Courier New', monospace;
-  }
-
-  [hidden] {
-    display: none !important;
-  }
-
-  p,
-  ul,
-  ol {
-    margin: 1rem 0;
-    font-size: 0.9375rem;
-    line-height: 1.5;
-  }
+  ${sharedStyles}
+  ${docsStyles}
 
   pre {
     white-space: pre-wrap;
-  }
-
-  a {
-    color: var(--ave-link-color);
-  }
-
-  a:hover {
-    color: var(--ave-link-hover-color);
   }
 
   button {
@@ -70,36 +28,9 @@ export default css`
   }
 
   api-viewer-content,
-  api-viewer-docs,
   api-viewer-demo,
   api-viewer-demo-layout {
     display: block;
-  }
-
-  header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 0.75rem;
-    background: var(--ave-primary-color);
-    border-top-left-radius: var(--ave-border-radius);
-    border-top-right-radius: var(--ave-border-radius);
-  }
-
-  .tag-name {
-    color: var(--ave-header-color);
-    font-family: var(--ave-monospace-font);
-    font-size: 0.875rem;
-    line-height: 1.5rem;
-  }
-
-  nav {
-    display: flex;
-    align-items: center;
-  }
-
-  [part='warning'] {
-    padding: 1rem;
   }
 
   [part='radio-label'] {
@@ -108,73 +39,7 @@ export default css`
     font-size: 0.875rem;
   }
 
-  [part='select-label'] {
-    margin-left: 0.5rem;
-  }
-
-  /* Docs styles */
-  [part='tab'][heading^='CSS'] {
-    font-size: 0.8125rem;
-  }
-
-  [part='docs-item'] {
-    display: block;
-    padding: 0.5rem;
-    color: var(--ave-item-color);
-  }
-
-  [part='docs-description'] {
-    display: block;
-    padding: 0 1rem;
-    border-bottom: solid 1px var(--ave-border-color);
-  }
-
-  [part='docs-row'] {
-    display: flex;
-    flex-wrap: wrap;
-    margin-bottom: 1rem;
-  }
-
-  [part='docs-column'] {
-    box-sizing: border-box;
-    flex-basis: 25%;
-    padding-right: 0.5rem;
-  }
-
-  [part='docs-column']:only-child {
-    flex-basis: 100%;
-  }
-
-  .column-name-css,
-  .column-type {
-    flex-basis: 50%;
-  }
-
-  [part='docs-label'] {
-    color: var(--ave-label-color);
-    font-size: 0.75rem;
-    line-height: 1rem;
-    letter-spacing: 0.1rem;
-  }
-
-  [part='docs-value'] {
-    font-family: var(--ave-monospace-font);
-    font-size: 0.875rem;
-    line-height: 1.5rem;
-  }
-
-  [part='docs-markdown'] p,
-  [part='docs-markdown'] ul,
-  [part='docs-markdown'] ol {
-    margin: 0.5rem 0;
-  }
-
-  .accent {
-    color: var(--ave-accent-color);
-  }
-
   /* Demo styles */
-  [part='docs-item']:not(:first-of-type),
   [part='demo-tabs'],
   [part='demo-output'] {
     border-top: solid 1px var(--ave-border-color);
@@ -254,7 +119,8 @@ export default css`
       margin-top: 1rem;
     }
 
-    .columns {
+    /* demo */
+    [part='knobs'] {
       flex-direction: column;
     }
 

--- a/src/api-viewer-styles.ts
+++ b/src/api-viewer-styles.ts
@@ -1,35 +1,14 @@
 import { css } from 'lit-element';
 import sharedStyles from './shared-styles.js';
 import docsStyles from './api-docs-styles.js';
+import demoStyles from './api-demo-styles.js';
 
 export default css`
   ${sharedStyles}
   ${docsStyles}
+  ${demoStyles}
 
-  pre {
-    white-space: pre-wrap;
-  }
-
-  button {
-    position: absolute;
-    top: 0.5rem;
-    right: 0.5rem;
-    text-transform: uppercase;
-    border: none;
-    border-radius: 0.25em;
-    cursor: pointer;
-    background: var(--ave-button-background, rgba(0, 0, 0, 0.3));
-    color: var(--ave-button-color, #fff);
-  }
-
-  button:focus,
-  button:hover {
-    background: var(--ave-button-active-background, rgba(0, 0, 0, 0.6));
-  }
-
-  api-viewer-content,
-  api-viewer-demo,
-  api-viewer-demo-layout {
+  api-viewer-content {
     display: block;
   }
 
@@ -37,95 +16,5 @@ export default css`
     margin: 0 0.75rem 0 0.25rem;
     color: var(--ave-header-color);
     font-size: 0.875rem;
-  }
-
-  /* Demo styles */
-  [part='demo-tabs'],
-  [part='demo-output'] {
-    border-top: solid 1px var(--ave-border-color);
-  }
-
-  [part='demo-tabs'] [part='tab-panel'] {
-    box-sizing: border-box;
-    position: relative;
-    background: #fafafa;
-  }
-
-  [part='demo-output'] {
-    padding: 1.5rem;
-    text-align: initial;
-    transform: translateZ(0);
-    overflow: hidden;
-  }
-
-  .source {
-    position: relative;
-  }
-
-  [part='knobs'] {
-    display: flex;
-    padding: 0 1rem 1rem;
-  }
-
-  [part='knobs-column'] {
-    width: 50%;
-  }
-
-  [part='knobs-header'] {
-    font-size: 1rem;
-    font-weight: bold;
-    margin: 1rem 0 0.25rem;
-  }
-
-  td {
-    padding: 0.25rem 0.25rem 0.25rem 0;
-    font-size: 0.9375rem;
-    white-space: nowrap;
-  }
-
-  [part='event-log'] {
-    display: block;
-    padding: 0 1rem;
-    min-height: 50px;
-    max-height: 200px;
-    overflow: auto;
-  }
-
-  [part='event-record'] {
-    margin: 0 0 0.25rem;
-    font-family: var(--ave-monospace-font);
-    font-size: 0.875rem;
-  }
-
-  [part='event-record']:first-of-type {
-    margin-top: 1rem;
-  }
-
-  [part='event-record']:last-of-type {
-    margin-bottom: 1rem;
-  }
-
-  @media (max-width: 480px) {
-    header {
-      flex-direction: column;
-    }
-
-    nav {
-      margin-top: 0.5rem;
-    }
-
-    .column-type {
-      flex-basis: 100%;
-      margin-top: 1rem;
-    }
-
-    /* demo */
-    [part='knobs'] {
-      flex-direction: column;
-    }
-
-    [part='knobs-column']:not(:last-child) {
-      margin-bottom: 1rem;
-    }
   }
 `;

--- a/src/shared-styles.ts
+++ b/src/shared-styles.ts
@@ -1,0 +1,75 @@
+import { css } from 'lit-element';
+
+export default css`
+  :host {
+    display: block;
+    text-align: left;
+    box-sizing: border-box;
+    max-width: 800px;
+    min-width: 360px;
+    font-size: 1rem;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+      'Oxygen-Sans', Ubuntu, Cantarell, sans-serif;
+    border: 1px solid var(--ave-border-color);
+    border-radius: var(--ave-border-radius);
+
+    --ave-primary-color: #01579b;
+    --ave-accent-color: #d63200;
+    --ave-border-color: rgba(0, 0, 0, 0.12);
+    --ave-border-radius: 4px;
+    --ave-header-color: #fff;
+    --ave-item-color: rgba(0, 0, 0, 0.87);
+    --ave-label-color: #424242;
+    --ave-link-color: #01579b;
+    --ave-link-hover-color: #d63200;
+    --ave-tab-indicator-size: 2px;
+    --ave-tab-color: rgba(0, 0, 0, 0.54);
+    --ave-monospace-font: Menlo, 'DejaVu Sans Mono', 'Liberation Mono', Consolas,
+      'Courier New', monospace;
+  }
+
+  :host([hidden]),
+  [hidden] {
+    display: none !important;
+  }
+
+  header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.75rem;
+    background: var(--ave-primary-color);
+    border-top-left-radius: var(--ave-border-radius);
+    border-top-right-radius: var(--ave-border-radius);
+  }
+
+  nav {
+    display: flex;
+    align-items: center;
+  }
+
+  [part='header-title'] {
+    color: var(--ave-header-color);
+    font-family: var(--ave-monospace-font);
+    font-size: 0.875rem;
+    line-height: 1.5rem;
+  }
+
+  [part='select-label'] {
+    margin-left: 0.5rem;
+  }
+
+  [part='warning'] {
+    padding: 1rem;
+  }
+
+  @media (max-width: 480px) {
+    header {
+      flex-direction: column;
+    }
+
+    nav {
+      margin-top: 0.5rem;
+    }
+  }
+`;


### PR DESCRIPTION
Fixes #14 

From now on, there will be 3 options:

- `<api-viewer>` - docs + demo
- `<api-docs>` - docs only
- `<api-demo>` - demo only