### PR TITLE
refactor: split slots logic to controller

### DIFF
--- a/src/api-demo-knobs-mixin.ts
+++ b/src/api-demo-knobs-mixin.ts
@@ -1,12 +1,10 @@
 import { LitElement, PropertyValues } from 'lit';
 import { property } from 'lit/decorators/property.js';
-import { getSlotDefault, Knob } from './lib/knobs.js';
+import { Knob } from './lib/knobs.js';
 import {
   ComponentWithProps,
   CSSPropertyInfo,
-  PropertyInfo,
-  SlotInfo,
-  SlotValue
+  PropertyInfo
 } from './lib/types.js';
 import {
   getTemplates,
@@ -135,16 +133,13 @@ export interface ApiDemoKnobsInterface extends HasKnobs {
   tag: string;
   props: PropertyInfo[];
   propKnobs: Knob<PropertyInfo>[];
-  slots: SlotInfo[];
   cssProps: CSSPropertyInfo[];
   exclude: string;
   vid?: number;
-  processedSlots: SlotValue[];
   processedCss: CSSPropertyInfo[];
   customKnobs: Knob<PropertyInfo>[];
   knobs: Record<string, Knob>;
   setKnobs(target: HTMLInputElement): void;
-  setSlots(target: HTMLInputElement): void;
   setCss(target: HTMLInputElement): void;
   initKnobs(component: HTMLElement): void;
 }
@@ -159,17 +154,11 @@ export const ApiDemoKnobsMixin = <T extends Constructor<LitElement>>(
     props: PropertyInfo[] = [];
 
     @property({ attribute: false })
-    slots: SlotInfo[] = [];
-
-    @property({ attribute: false })
     cssProps: CSSPropertyInfo[] = [];
 
     @property() exclude = '';
 
     @property({ type: Number }) vid?: number;
-
-    @property({ attribute: false })
-    processedSlots!: SlotValue[];
 
     @property({ attribute: false })
     processedCss!: CSSPropertyInfo[];
@@ -188,28 +177,8 @@ export const ApiDemoKnobsMixin = <T extends Constructor<LitElement>>(
       if (props.has('tag')) {
         this.knobs = {};
         this.processedCss = [];
-        this.processedSlots = [];
         this.propKnobs = getKnobs(this.tag, this.props, this.exclude);
         this.customKnobs = getCustomKnobs(this.tag, this.vid);
-      }
-
-      if (props.has('slots') && this.slots) {
-        this.processedSlots = this.slots
-          .sort((a: SlotInfo, b: SlotInfo) => {
-            if (a.name === '') {
-              return 1;
-            }
-            if (b.name === '') {
-              return -1;
-            }
-            return a.name.localeCompare(b.name);
-          })
-          .map((slot: SlotInfo) => {
-            return {
-              ...slot,
-              content: getSlotDefault(slot.name, 'content')
-            };
-          });
       }
     }
 
@@ -267,20 +236,6 @@ export const ApiDemoKnobsMixin = <T extends Constructor<LitElement>>(
           } as Knob<PropertyInfo>
         };
       }
-    }
-
-    setSlots(target: HTMLInputElement): void {
-      const name = target.dataset.slot;
-      const content = target.value;
-
-      this.processedSlots = this.processedSlots.map((slot) => {
-        return slot.name === name
-          ? {
-              ...slot,
-              content
-            }
-          : slot;
-      });
     }
 
     initKnobs(component: HTMLElement) {

--- a/src/api-viewer-demo.ts
+++ b/src/api-viewer-demo.ts
@@ -53,7 +53,7 @@ class ApiViewerDemo extends ApiDemoKnobsMixin(LitElement) {
 
       return html`
         <div part="warning">
-          Element ${this.tag} is not defined. Have you imported it?
+          Element ${tag} is not defined. Have you imported it?
         </div>
       `;
     }
@@ -69,7 +69,7 @@ class ApiViewerDemo extends ApiDemoKnobsMixin(LitElement) {
     const id = this.vid as number;
     const log = this.eventsController?.log || [];
     const slots = this.slotsController?.slots || [];
-    const hideSlots = noSlots || hasTemplate(id, this.tag, TemplateTypes.SLOT);
+    const hideSlots = noSlots || hasTemplate(id, tag, TemplateTypes.SLOT);
 
     return html`
       <div part="demo-output" @rendered=${this.onRendered}>
@@ -87,7 +87,7 @@ class ApiViewerDemo extends ApiDemoKnobsMixin(LitElement) {
             ${this.copyBtnText}
           </button>
           <div part="demo-snippet">
-            ${renderSnippet(id, this.tag, this.knobs, slots, this.processedCss)}
+            ${renderSnippet(id, tag, this.knobs, slots, this.processedCss)}
           </div>
         </api-viewer-panel>
         <api-viewer-tab

--- a/src/controllers/slots-controller.ts
+++ b/src/controllers/slots-controller.ts
@@ -1,0 +1,84 @@
+import { ReactiveController, ReactiveControllerHost } from 'lit';
+import { getSlotDefault } from '../lib/knobs.js';
+import { SlotInfo, SlotValue } from '../lib/types.js';
+import { hasTemplate, TemplateTypes } from '../lib/utils.js';
+
+export class SlotsController {
+  host: ReactiveControllerHost;
+
+  enabled: boolean;
+
+  el: HTMLElement;
+
+  private _slots: SlotValue[] = [];
+
+  get slots(): SlotValue[] {
+    return this._slots;
+  }
+
+  set slots(slots: SlotValue[]) {
+    this._slots = slots;
+
+    // Apply slots content by re-creating nodes
+    if (this.enabled && this.el.isConnected && slots && slots.length) {
+      this.el.innerHTML = '';
+      slots.forEach((slot) => {
+        let node: Element | Text;
+        const { name, content } = slot;
+        if (name) {
+          node = document.createElement('div');
+          node.setAttribute('slot', name);
+          node.textContent = content;
+        } else {
+          node = document.createTextNode(content);
+        }
+        this.el.appendChild(node);
+      });
+    }
+
+    // Update the demo snippet
+    this.host.requestUpdate();
+  }
+
+  constructor(
+    host: ReactiveControllerHost,
+    id: number,
+    component: HTMLElement,
+    slots: SlotInfo[]
+  ) {
+    (this.host = host).addController(this as ReactiveController);
+    this.el = component;
+    this.enabled = !hasTemplate(id, component.localName, TemplateTypes.SLOT);
+    this.slots = slots
+      .sort((a: SlotInfo, b: SlotInfo) => {
+        if (a.name === '') {
+          return 1;
+        }
+        if (b.name === '') {
+          return -1;
+        }
+        return a.name.localeCompare(b.name);
+      })
+      .map((slot: SlotInfo) => {
+        return {
+          ...slot,
+          content: getSlotDefault(slot.name, 'content')
+        };
+      }) as SlotValue[];
+  }
+
+  hostDisconnected() {
+    this.slots = [];
+  }
+
+  setValue(name: string, content: string) {
+    this.slots = this.slots.map((slot) => {
+      return slot.name === name
+        ? {
+            ...slot,
+            content
+          }
+        : slot;
+    });
+  }
+}

--- a/src/controllers/slots-controller.ts
+++ b/src/controllers/slots-controller.ts
@@ -3,7 +3,7 @@ import { getSlotDefault } from '../lib/knobs.js';
 import { SlotInfo, SlotValue } from '../lib/types.js';
 import { hasTemplate, TemplateTypes } from '../lib/utils.js';
 
-export class SlotsController {
+export class SlotsController implements ReactiveController {
   host: ReactiveControllerHost;
 
   enabled: boolean;

--- a/src/lib/renderer.ts
+++ b/src/lib/renderer.ts
@@ -3,11 +3,10 @@ import { directive, Directive, PartInfo, PartType } from 'lit/directive.js';
 import { templateContent } from 'lit/directives/template-content.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { Knob } from './knobs.js';
-import { CSSPropertyInfo, SlotValue } from './types.js';
+import { CSSPropertyInfo } from './types.js';
 import {
   getTemplate,
   getTemplateNode,
-  hasTemplate,
   isTemplate,
   normalizeType,
   TemplateTypes
@@ -17,7 +16,6 @@ export type ComponentRendererOptions = {
   id: number;
   tag: string;
   knobs: Record<string, Knob>;
-  slots: SlotValue[];
   cssProps: CSSPropertyInfo[];
 };
 
@@ -27,7 +25,7 @@ const updateComponent = (
   component: HTMLElement,
   options: ComponentRendererOptions
 ): void => {
-  const { id, tag, knobs, slots, cssProps } = options;
+  const { knobs, cssProps } = options;
 
   // Apply knobs using properties or attributes
   Object.keys(knobs).forEach((key: string) => {
@@ -44,23 +42,6 @@ const updateComponent = (
       (component as any)[key] = value;
     }
   });
-
-  // Apply slots content by re-creating nodes
-  if (!hasTemplate(id, tag, SLOT) && slots.length) {
-    component.innerHTML = '';
-    slots.forEach((slot) => {
-      let node: Element | Text;
-      const { name, content } = slot;
-      if (name) {
-        node = document.createElement('div');
-        node.setAttribute('slot', name);
-        node.textContent = content;
-      } else {
-        node = document.createTextNode(content);
-      }
-      component.appendChild(node);
-    });
-  }
 
   // Apply CSS props
   if (cssProps.length) {


### PR DESCRIPTION
## Motivation

Follow-up from #91 but for slots. This also helps to make `renderer` directive slightly cleaner.