### PR TITLE
docs: add missing links to categories pages

### DIFF
--- a/docs/docs/api/index.md
+++ b/docs/docs/api/index.md
@@ -1,1 +1,6 @@
 # API || 20
+
+- [Elements](./elements/)
+- [Properties](./properties/)
+- [Templates](./templates/)
+- [Styling](./styling/)

--- a/docs/docs/examples/index.md
+++ b/docs/docs/examples/index.md
@@ -1,1 +1,6 @@
 # Examples || 30
+
+- [`<api-viewer>`](./api-viewer/)
+- [`<api-docs>`](./api-docs/)
+- [`<api-demo>`](./api-demo/)
+- [Theming](./theming/)

--- a/docs/docs/guide/index.md
+++ b/docs/docs/guide/index.md
@@ -1,1 +1,5 @@
 # Guide || 10
+
+- [Introduction](./intro/)
+- [Writing JSDoc](./writing-jsdoc/)
+- [Using demo](./using-demo/)


### PR DESCRIPTION
The categories `index` pages were missing links to their content articles, this is now fixed.