### PR TITLE
docs: add cross-references, minor improvements

### DIFF
--- a/docs/docs/api/elements.md
+++ b/docs/docs/api/elements.md
@@ -1,7 +1,7 @@
 # API >> Elements || 10
 
 API Viewer consists of two major features: documentation and demo (interactive live playground).
-Both features reuse the same manifest data, by default you can switch between them using radio buttons.
+Both features reuse the same [manifest data](../../guide/writing-jsdoc/), by default you can switch between them using radio buttons.
 
 Alternatively, you can use separate elements for documentation and demo.
 This does not mean having to load manifest data twice: it can be fetched once and then passed to the elements using `manifest` property.
@@ -50,7 +50,7 @@ Do not pass any base class directly to `customElements.define()`: make sure to e
 ### `ApiViewerBase` class
 
 A class that you can use to create your own version of `<api-viewer>`.
-If you don't need `<template>` support in the live demo, feel free to remove corresponding code.
+If you don't need [`<template>` support](../templates/) in the live demo, feel free to remove corresponding code.
 API documentation does not use templates.
 
 ```js

--- a/docs/docs/api/templates.md
+++ b/docs/docs/api/templates.md
@@ -1,12 +1,12 @@
 # API >> Templates || 30
 
-API Viewer uses the [`<template>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template) element to configure the live demo.
-Templates can be used to customize the default values for properties, to setup custom knobs, and to provide wrapper, prefix, or suffix elements.
+API Viewer uses the [`<template>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template) element for configuring the live demo.
+With templates, you can customize the default properties values, set up custom [knobs](../../guide/using-demo/#knobs), or provide additional HTML to be shown in the demo.
 
 ## Setting templates
 
-Both `<api-viewer>` and `<api-demo>` elements collect template passing to them declaratively at the time of initialization.
-Alternatively, you can call `setTemplates()` method to provide `<template>` elements lazily.
+Both `<api-viewer>` and `<api-demo>` elements collect `<template>` elements passed to them declaratively at the time of initialization.
+Alternatively, you can call `setTemplates()` method to provide a set of templates lazily.
 
 ```js
 // Father the template elements placed in the DOM

--- a/docs/docs/guide/using-demo.md
+++ b/docs/docs/guide/using-demo.md
@@ -5,7 +5,7 @@ Several panels are available depending on the functionality the component suppor
 
 ## Importing
 
-In order to enable live demos, import the components documented in the manifest.
+In order to use live demo, import the components documented in the manifest.
 The demo component uses [`customElements.whenDefined()`](https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/whenDefined), which returns a Promise, so importing the components lazily also works.
 
 ```html
@@ -15,12 +15,13 @@ The demo component uses [`customElements.whenDefined()`](https://developer.mozil
 <api-viewer src="./custom-elements.json"></api-viewer>
 ```
 
-If you want to render live demo separately from the API documentation, consider using `<api-demo>` element instead of the `<api-viewer>`.
+If you want to render live demo separately from the API documentation, consider using [`<api-demo>`](../../examples/api-demo/) element instead of the `<api-viewer>`.
 All of the features and use cases listed below apply to both components.
 
 ## Source
 
-The Source panel contains an HTML code snippet representing the component with its properties, HTML attributes and slots.
+The Source panel contains an HTML code snippet representing the component with its
+[properties](../writing-jsdoc/#properties), HTML attributes and [slots](../writing-jsdoc/#slots).
 When setting knobs or styles using corresponding panels, code snippet is updated.
 
 For example, changing a custom CSS property to the value other than the default one will add `<style>` tag to the snippet.
@@ -34,7 +35,8 @@ Play with the component to tweak its appearance, set `textContent` for its `<slo
 Knobs panel is of the live demo inspired by corresponding Storybook addon.
 It allows to toggle properties, attributes and set slots content on the element instance, and updates the code snippet accordingly.
 
-The playground listens to the events dispatched by the component and uses `[property]-changed` events to sync knobs controls with the component's state.
+The playground listens to the [events](../writing-jsdoc/#events) dispatched by the component
+and uses `[property]-changed` events to sync knobs controls with the component's state.
 This is useful if the component handles user input:
 
 ```js
@@ -50,7 +52,7 @@ This is useful if the component handles user input:
 
 ## Styles
 
-The live demo relies on the analyzer to get default values for documented custom CSS properties.
+The live demo relies on the analyzer to get default values for documented [CSS Custom Properties](../writing-jsdoc/#css-custom-properties).
 As a fallback, it collects the values on the rendered component using `getComputedStyle(element).getPropertyValue()`.
 
 We recommend using the following CSS structure to provide styling API for web components to make Styles panel work.


### PR DESCRIPTION
Added some links between different docs pages to make navigation easier. Also, improved wording a bit.