### PR TITLE
fix: reset selected tab when element changes

### DIFF
--- a/src/api-viewer-demo.ts
+++ b/src/api-viewer-demo.ts
@@ -201,6 +201,16 @@ class ApiViewerDemo extends LitElement {
     }
   }
 
+  protected updated(props: PropertyValues): void {
+    // Reset the focused tab
+    if (props.has('tag') && props.get('tag')) {
+      const tabs = this.renderRoot.querySelector('api-viewer-tabs');
+      if (tabs) {
+        tabs.selectFirst();
+      }
+    }
+  }
+
   private _onLogClear(): void {
     this.eventsController.clear();
     const tab = this.querySelector('#events') as HTMLElement;


### PR DESCRIPTION
Copied the corresponding code from `api-viewer-docs` to reset the tab when changing the selected element.