### PR TITLE
fix: do now throw when panel does not exist

### DIFF
--- a/src/api-viewer-tabs.ts
+++ b/src/api-viewer-tabs.ts
@@ -179,11 +179,10 @@ export class ApiViewerTabs extends LitElement {
     this.reset();
 
     const newPanel = this._panelForTab(newTab);
-    if (!newPanel) {
-      throw new Error('No panel with for tab');
+    if (newPanel) {
+      newTab.selected = true;
+      newPanel.hidden = false;
     }
-    newTab.selected = true;
-    newPanel.hidden = false;
   }
 
   private _onKeyDown(event: KeyboardEvent): void {


### PR DESCRIPTION
There was an error when switching from an element not having any API to the other one that does have API.
This workaround prevents an error from being thrown. I will try to come up with a better fix later.