### PR TITLE
fix: add missing .js extension to imports

### DIFF
--- a/src/lib/demo-snippet.ts
+++ b/src/lib/demo-snippet.ts
@@ -1,9 +1,9 @@
 import { html, TemplateResult } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
-import { htmlRender } from 'highlight-ts/es/render/html';
-import { registerLanguages } from 'highlight-ts/es/languages';
-import { XML } from 'highlight-ts/es/languages/xml';
-import { init, process } from 'highlight-ts/es/process';
+import { htmlRender } from 'highlight-ts/es/render/html.js';
+import { registerLanguages } from 'highlight-ts/es/languages.js';
+import { XML } from 'highlight-ts/es/languages/xml.js';
+import { init, process } from 'highlight-ts/es/process.js';
 import { CssCustomPropertyValue, SlotValue } from './manifest.js';
 import { Knob } from './knobs.js';
 import { CSS } from './highlight-css.js';

--- a/src/lib/highlight-css.ts
+++ b/src/lib/highlight-css.ts
@@ -1,10 +1,10 @@
-import { LanguageDef } from 'highlight-ts/es/types';
+import { LanguageDef } from 'highlight-ts/es/types.js';
 import {
   APOS_STRING_MODE,
   QUOTE_STRING_MODE,
   CSS_NUMBER_MODE,
   C_BLOCK_COMMENT_MODE
-} from 'highlight-ts/es/common';
+} from 'highlight-ts/es/common.js';
 
 const FUNCTION_LIKE = {
   begin: /[\w-]+\(/,


### PR DESCRIPTION
This caused the `size-limit` to fail, and in general we need `.js` extensions when using ES modules.