### PR TITLE
fix: root path lookup

### DIFF
--- a/src/lib/manifest.ts
+++ b/src/lib/manifest.ts
@@ -97,7 +97,7 @@ export const getElementData = (
             y?.name === element.declaration.name
         )
     : manifest.modules
-        .find((m) => m.path === element.declaration.module)
+        .find((m) => m.path === element.declaration.module.replace(/^\//, ''))
         ?.declarations?.find((d) => d.name === element.declaration.name);
 
   if (!decl || !isCustomElementDeclaration(decl)) {


### PR DESCRIPTION
This is an extract from my `custom-elements.json`

```json
    {
      "kind": "javascript-module",
      "path": "mdjs-layout/define.js",
      "declarations": [],
      "exports": [
        {
          "kind": "custom-element-definition",
          "name": "mdjs-layout",
          "declaration": {
            "name": "MdjsLayout",
            "module": "/mdjs-layout/src/mdjs-layout.ts"
          }
        }
      ]
    },

...

    {
      "kind": "javascript-module",
      "path": "mdjs-layout/src/mdjs-layout.ts",
      "declarations": [
        {
          "kind": "class",
          "description": "",
          "name": "MdjsLayout",
          "members": [
```

Since the export module has a leading slash, while the path doesn't, it's not found

```
"module": "/mdjs-layout/src/mdjs-layout.ts"
   "path": "mdjs-layout/src/mdjs-layout.ts",
```

I think it's correct to assume that if the `module` path starts with a leading slash, it refers to a root path, so we can remove it while searching for the correct declaration `path`.

However, this might be also a bug in `@custom-elements-manifest/analyzer`, in the test fixtures I never saw the `module` having the leading slash (e.g. [this fixture doesn't have it](https://github.com/open-wc/custom-elements-manifest/blob/a79ba9a4dab947c8c1b00879376b38347ce43333/packages/analyzer/fixtures/class-attributes/output.json#L102)), so I'll check with Pascal if this is working as intended in the analyzer too.