### PR TITLE
fix: selected tab border radius

### DIFF
--- a/src/api-viewer-tabs.ts
+++ b/src/api-viewer-tabs.ts
@@ -18,6 +18,8 @@ export class ApiViewerTabs extends LitElement {
     return css`
       :host {
         display: flex;
+        border-bottom-left-radius: var(--ave-border-radius);
+        overflow: hidden;
       }
 
       .tabs {


### PR DESCRIPTION
Fixes this small overflow issue:

![image](https://user-images.githubusercontent.com/137844/145192254-afd9c958-c318-4a5c-94ac-ba558577c6b3.png)

Fix is implemented in such a way that the situation with more content is covered too:

![image](https://user-images.githubusercontent.com/137844/145192501-ebdb9717-8f1e-4a38-920a-c05ae863b04e.png)
